### PR TITLE
fix compatibility with PHP < 5.3.9

### DIFF
--- a/src/cogpowered/FineDiff/Granularity/GranularityInterface.php
+++ b/src/cogpowered/FineDiff/Granularity/GranularityInterface.php
@@ -20,11 +20,6 @@ namespace cogpowered\FineDiff\Granularity;
 
 interface GranularityInterface
 {
-    public function offsetExists($offset);
-    public function offsetGet($offset);
-    public function offsetSet($offset, $value);
-    public function offsetUnset($offset);
-
     /**
      * Get the delimiters that make up the granularity.
      *


### PR DESCRIPTION
Remove methods from GranularityInterface that are already defined in ArrayAccess.

Prior to PHP 5.3.9, a class could not implement two interfaces that specified a method with the same name, since it would cause ambiguity. More recent versions of PHP allow this as long as the duplicate methods have the same signature. [source](http://php.net/manual/en/language.oop5.interfaces.php)

Without this fix, trying to use this class simply exits with this error: 

> ( ! ) Fatal error: Can't inherit abstract function ArrayAccess::offsetExists() (previously declared abstract in cogpowered\FineDiff\Granularity\GranularityInterface) in /www/supermagnete/testpsc_docs/vendor/cogpowered/finediff/src/cogpowered/FineDiff/Granularity/Granularity.php on line 24
